### PR TITLE
Fix documentation links and extract build procedure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,39 @@
+## Testing builds locally
+
+```bash
+# from the root of this workspace
+npm pack --workspace ./packages
+
+# in your project's folder
+yarn add ../formik-material-ui/formik-material-ui-4.0.0.tgz
+yarn add ../formik-material-ui/formik-material-ui-lab-1.0.0.tgz
+```
+
+## Publishing a new version
+
+```bash
+# before having merged to master
+
+# bump desired packages to a major alpha version
+yarn version --premajor --preid alpha --no-git-tag-version
+yarn workspace @mercantile/formik-material-ui version --premajor --preid alpha --no-git-tag-version
+yarn workspace @mercantile/formik-material-ui-lab version --premajor --preid alpha --no-git-tag-version
+# or simply bump the prelease version
+yarn version --prerelease --no-git-tag-version
+yarn workspace @mercantile/formik-material-ui version --prerelease --no-git-tag-version
+yarn workspace @mercantile/formik-material-ui-lab version --prerelease --no-git-tag-version
+
+# once you have merged to master, do the following:
+
+# create git tag and push it
+git tag -a @mercantile/formik-material-ui@4.0.0-alpha.0 -m "@mercantile/formik-material-ui version 4.0.0-alpha.0"
+git push origin @mercantile/formik-material-ui@4.0.0-alpha.0
+
+git tag -a @mercantile/formik-material-ui-lab@1.0.0-alpha.0 -m "@mercantile/formik-material-ui-lab version 1.0.0-alpha.0"
+git push origin @mercantile/formik-material-ui-lab@1.0.0-alpha.0
+
+# publish
+npm login
+yarn workspace @mercantile/formik-material-ui publish --access public --tag alpha
+yarn workspace @mercantile/formik-material-ui-lab publish --access public --tag alpha
+```

--- a/packages/formik-material-ui-lab/README.md
+++ b/packages/formik-material-ui-lab/README.md
@@ -5,6 +5,6 @@
 
 Bindings for using [Formik](https://github.com/jaredpalmer/formik) with [MUI](https://mui.com/).
 
-- [Documentation](../../docs/docs/api/material-ui-lab.md)
+- [Documentation](https://github.com/mercantile/formik-material-ui/blob/next/docs/docs/api/material-ui-lab.md)
 
 This project requires Formik>= 2.0.0. For Formik one please use formik-material-ui@1.0.x

--- a/packages/formik-material-ui/README.md
+++ b/packages/formik-material-ui/README.md
@@ -6,47 +6,8 @@
 
 Fork of [formik-material-ui](https://github.com/mercantile/formik-material-ui). Bindings for using [Formik](https://github.com/jaredpalmer/formik) with [MUI](https://mui.com/).
 
-- [Getting started](./docs/docs/guide/getting-started.md)
-- [Documentation for formik-material-ui](./docs/docs/api/material-ui.md)
-- [Documentation for formik-material-ui-lab](./docs/docs/api/material-ui.md)
+- [Getting started](https://github.com/mercantile/formik-material-ui/blob/next/docs/docs/guide/getting-started.md)
+- [Documentation for formik-material-ui](https://github.com/mercantile/formik-material-ui/blob/next/docs/docs/api/material-ui.md)
+- [Documentation for formik-material-ui-lab](https://github.com/mercantile/formik-material-ui/blob/next/docs/docs/api/material-ui.md)
 
 This project requires Formik>= 2.0.0. For Formik one please use formik-material-ui@1.0.x
-
-## Testing builds locally
-
-```bash
-# from the root of this workspace
-npm pack --workspace ./packages
-
-# in your project's folder
-yarn add ../formik-material-ui/formik-material-ui-4.0.0.tgz
-yarn add ../formik-material-ui/formik-material-ui-lab-1.0.0.tgz
-```
-
-## Publishing a new version
-
-```bash
-# before having merged to master
-
-# bump desired packages to a major alpha version
-yarn version --premajor --preid alpha --no-git-tag-version
-yarn workspace @mercantile/formik-material-ui version --premajor --preid alpha --no-git-tag-version
-yarn workspace @mercantile/formik-material-ui-lab version --premajor --preid alpha --no-git-tag-version
-# or simply bump the prelease version
-yarn version --prerelease --no-git-tag-version
-yarn workspace @mercantile/formik-material-ui version --prerelease --no-git-tag-version
-yarn workspace @mercantile/formik-material-ui-lab version --prerelease --no-git-tag-version
-
-# once you have merged to master, do the following:
-
-# create git tag and push it
-git tag -a @mercantile/formik-material-ui@4.0.0-alpha.0 -m "@mercantile/formik-material-ui version 4.0.0-alpha.0"
-git push origin @mercantile/formik-material-ui@4.0.0-alpha.0
-
-git tag -a @mercantile/formik-material-ui-lab@1.0.0-alpha.0 -m "@mercantile/formik-material-ui-lab version 1.0.0-alpha.0"
-git push origin @mercantile/formik-material-ui-lab@1.0.0-alpha.0
-
-# publish
-yarn workspace @mercantile/formik-material-ui publish --access public --tag alpha
-yarn workspace @mercantile/formik-material-ui-lab publish --access public --tag alpha
-```


### PR DESCRIPTION
Links were broken on the npm package (referencing `master` instead of `next`), and having build steps in there made no sense.