### PR TITLE
Release alpha 2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,8 @@
 
 ```bash
 # from the root of this workspace
+yarn workspace @mercantile/formik-material-ui package
+yarn workspace @mercantile/formik-material-ui-lab package
 npm pack --workspace ./packages
 
 # in your project's folder

--- a/packages/formik-material-ui-lab/package.json
+++ b/packages/formik-material-ui-lab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mercantile/formik-material-ui-lab",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "license": "MIT",
   "typings": "dist/main.d.ts",
   "peerDependencies": {

--- a/packages/formik-material-ui-lab/src/DatePicker.tsx
+++ b/packages/formik-material-ui-lab/src/DatePicker.tsx
@@ -14,8 +14,15 @@ export interface DatePickerProps
 
 export function fieldToDatePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToDatePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToDatePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/DateTimePicker.tsx
+++ b/packages/formik-material-ui-lab/src/DateTimePicker.tsx
@@ -14,8 +14,15 @@ export interface DateTimePickerProps
 
 export function fieldToDateTimePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToDateTimePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToDateTimePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/DesktopDatePicker.tsx
+++ b/packages/formik-material-ui-lab/src/DesktopDatePicker.tsx
@@ -14,8 +14,15 @@ export interface DesktopDatePickerProps
 
 export function fieldToDesktopDatePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToDesktopDatePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToDesktopDatePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/DesktopDateTimePicker.tsx
+++ b/packages/formik-material-ui-lab/src/DesktopDateTimePicker.tsx
@@ -14,8 +14,15 @@ export interface DesktopDateTimePickerProps
 
 export function fieldToDesktopDateTimePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToDesktopDateTimePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToDesktopDateTimePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/DesktopTimePicker.tsx
+++ b/packages/formik-material-ui-lab/src/DesktopTimePicker.tsx
@@ -14,8 +14,15 @@ export interface DesktopTimePickerProps
 
 export function fieldToDesktopTimePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToDesktopTimePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToDesktopTimePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/MobileDatePicker.tsx
+++ b/packages/formik-material-ui-lab/src/MobileDatePicker.tsx
@@ -14,8 +14,15 @@ export interface MobileDatePickerProps
 
 export function fieldToMobileDatePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToMobileDatePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToMobileDatePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/MobileDateTimePicker.tsx
+++ b/packages/formik-material-ui-lab/src/MobileDateTimePicker.tsx
@@ -14,8 +14,15 @@ export interface MobileDateTimePickerProps
 
 export function fieldToMobileDateTimePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToMobileDateTimePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToMobileDateTimePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/MobileTimePicker.tsx
+++ b/packages/formik-material-ui-lab/src/MobileTimePicker.tsx
@@ -14,8 +14,15 @@ export interface MobileTimePickerProps
 
 export function fieldToMobileTimePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToMobileTimePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToMobileTimePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/StaticDatePicker.tsx
+++ b/packages/formik-material-ui-lab/src/StaticDatePicker.tsx
@@ -14,8 +14,15 @@ export interface StaticDatePickerProps
 
 export function fieldToStaticDatePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToStaticDatePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToStaticDatePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/StaticDateTimePicker.tsx
+++ b/packages/formik-material-ui-lab/src/StaticDateTimePicker.tsx
@@ -14,8 +14,15 @@ export interface StaticDateTimePickerProps
 
 export function fieldToStaticDateTimePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToStaticDateTimePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToStaticDateTimePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/StaticTimePicker.tsx
+++ b/packages/formik-material-ui-lab/src/StaticTimePicker.tsx
@@ -14,8 +14,15 @@ export interface StaticTimePickerProps
 
 export function fieldToStaticTimePicker({
   field: { onChange: _onChange, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToStaticTimePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToStaticTimePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),

--- a/packages/formik-material-ui-lab/src/TimePicker.tsx
+++ b/packages/formik-material-ui-lab/src/TimePicker.tsx
@@ -14,8 +14,15 @@ export interface TimePickerProps
 
 export function fieldToTimePicker({
   field: { onChange: _onChange, onBlur: fieldOnBlur, ...field },
-  form: { isSubmitting, touched, errors, setFieldValue, setFieldError },
-  textField: { helperText, ...textField } = {},
+  form: {
+    isSubmitting,
+    touched,
+    errors,
+    setFieldValue,
+    setFieldError,
+    setFieldTouched,
+  },
+  textField: { helperText, onBlur, ...textField } = {},
   disabled,
   label,
   onChange,
@@ -35,6 +42,12 @@ export function fieldToTimePicker({
           error={showError}
           helperText={showError ? fieldError : helperText}
           label={label}
+          onBlur={
+            onBlur ??
+            function () {
+              setFieldTouched(field.name, true, true);
+            }
+          }
           {...textField}
         />
       )),
@@ -42,7 +55,10 @@ export function fieldToTimePicker({
     onChange:
       onChange ??
       function (date) {
-        setFieldValue(field.name, date);
+        // Do not switch this order, otherwise you might cause a race condition
+        // See https://github.com/formium/formik/issues/2083#issuecomment-884831583
+        setFieldTouched(field.name, true, false);
+        setFieldValue(field.name, date, true);
       },
     onError:
       onError ?? createErrorHandler(fieldError, field.name, setFieldError),


### PR DESCRIPTION
This fixes the validation of date pickers which was not being properly triggered. It seems like some more formik handling is required since the pickers implementation changed with MUI 5.

Will cherry-pick commit https://github.com/mercantile/formik-material-ui/commit/2f87bc4e599070bbcd021921de963b31622c4e80 into the official [PR](https://github.com/stackworx/formik-material-ui/pull/291) once this is merged.